### PR TITLE
fix: format month error

### DIFF
--- a/src/pages/api/users/[username]/blocked-dates.api.ts
+++ b/src/pages/api/users/[username]/blocked-dates.api.ts
@@ -41,6 +41,8 @@ export default async function handler(
       (availableWeekDay) => availableWeekDay.week_day === weekDay,
     )
   })
+  
+  const monthWithLeftNumber = String(month).padStart(2, '0')
 
   const blockedDatesRaw: Array<{ date: number }> = await prisma.$queryRaw`
     SELECT
@@ -54,7 +56,7 @@ export default async function handler(
       ON UTI.week_day = WEEKDAY(DATE_ADD(S.date, INTERVAL 1 DAY))
 
     WHERE S.user_id = ${user.id}
-      AND DATE_FORMAT(S.date, "%Y-%m") = ${`${year}-${month}`}
+      AND DATE_FORMAT(S.date, "%Y-%m") = ${`${year}-${monthWithLeftNumber}`}
 
     GROUP BY EXTRACT(DAY FROM S.DATE),
       ((UTI.time_end_in_minutes - UTI.time_start_in_minutes) / 60)


### PR DESCRIPTION
## Descrição

O código original tinha um erro na formatação do mês em uma query SQL, onde ao receber um número menor que 10, retornava apenas um dígito, quando o correto seria retornar dois dígitos com um zero a esquerda. 

Como o Diego passava o month na query como 11 ou 12 não acontecia esse erro, mas, quando era um numero abaixo de 10, exemplo 9, não retorna o esperado.

## Solução

A solução que eu utilizei foi o método padStart() do JavaScript para adicionar o zero à esquerda e corrigir a formatação do número. Em seguida, a variável corrigida foi passada como parâmetro para a query SQL, eliminando assim o erro na formatação do mês. Com essa correção, o mês é exibido corretamente na consulta SQL, sem a necessidade de escrever diretamente na URL.